### PR TITLE
Implement streaming chat support

### DIFF
--- a/src/anthropic/models.rs
+++ b/src/anthropic/models.rs
@@ -305,4 +305,12 @@ impl ChatMessage {
             })
             .collect()
     }
+
+    /// Check if the message has no meaningful content
+    pub fn has_empty_content(&self) -> bool {
+        self.content.iter().all(|block| match block {
+            ContentBlock::Text { text } => text.trim().is_empty(),
+            _ => false,
+        })
+    }
 }


### PR DESCRIPTION
## Summary
- implement streaming support in `AnthropicClient::chat_stream`
- add a small SSE-based test exercising streaming
- provide helper `ChatMessage::has_empty_content`

## Testing
- `cargo test --quiet --tests`

------
https://chatgpt.com/codex/tasks/task_e_6849f064389483249c9a6ab21f21042a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled streaming chat responses, allowing real-time message updates during conversations.
	- Added detection for empty chat message content.
- **Bug Fixes**
	- Improved error handling for incomplete or invalid streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->