### PR TITLE
Remove outdated mp4 references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 # Optional: Set log level (trace, debug, info, warn, error)
 RUST_LOG=info
 
-# Optional: Memory file path
-# MEMORY_PATH=agent_memory.mp4
+# Optional: Memory file path (JSON used by rust-synaptic)
+# MEMORY_PATH=agent_memory.json

--- a/agent_config.toml.example
+++ b/agent_config.toml.example
@@ -27,10 +27,10 @@ timeout_seconds = 60
 max_retries = 3
 
 [memory]
-# Path to the memory file (JSON format)
+# Path to the JSON memory file used by rust-synaptic
 memory_path = "agent_memory.json"
 
-# Base path for the memory index (synaptic adds extensions)
+# Base path for the synaptic index (extensions like .metadata are appended)
 index_path = "agent_memory"
 
 # Enable automatic memory saving

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -39,9 +39,9 @@ pub struct AnthropicConfig {
 /// Memory system configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryConfig {
-    /// Path to the memory file (JSON)
+    /// Path to the JSON memory file used by rust-synaptic
     pub memory_path: PathBuf,
-    /// Base path for the memory index (synaptic will append extensions)
+    /// Base path for the synaptic index (extensions are appended automatically)
     pub index_path: PathBuf,
     /// Enable automatic memory saving
     pub auto_save: bool,
@@ -126,7 +126,7 @@ impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
             memory_path: PathBuf::from("agent_memory.json"),
-            index_path: PathBuf::from("agent_memory"), // Base path - synaptic memory will add .metadata and .vector extensions
+            index_path: PathBuf::from("agent_memory"), // Base path - synaptic adds .metadata and .vector files
             auto_save: true,
             max_conversations: 1000,
             enable_search: true,
@@ -310,7 +310,8 @@ impl AgentConfig {
         self
     }
 
-    /// Set the memory path
+    /// Set the path to the JSON memory file. The synaptic index will reuse
+    /// the same base name with `.metadata` and `.vector` extensions.
     pub fn with_memory_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
         let path = path.into();
         self.memory.memory_path = path.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 
 #[derive(Parser)]
 #[command(name = "memvid-agent")]
-#[command(about = "AI agent with MP4 memory and Anthropic integration")]
+#[command(about = "AI agent with synaptic JSON memory and Anthropic integration")]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- remove old `.mp4` example paths
- document JSON synaptic memory usage in config docs and CLI help

## Testing
- `cargo test --workspace --lib` *(fails: could not compile `synaptic`)*

------
https://chatgpt.com/codex/tasks/task_e_684a2c76f008832490c83b66b1309a56